### PR TITLE
feat(opencode): add OpenCode global configuration

### DIFF
--- a/config/opencode/AGENTS.md
+++ b/config/opencode/AGENTS.md
@@ -1,0 +1,49 @@
+# Global OpenCode Rules
+
+## Critical Instructions
+
+- **ALWAYS write over the source file you're editing.** Don't make "\_enhanced", "\_fixed", "\_updated", or "\_v2" versions. We use JJ for version control. If unsure, commit first then overwrite.
+- Don't make "dashboards" or figures with a lot of plots in one image file. It's hard for AIs to figure out what all is going on.
+- When the user requests code examples, setup or configuration steps, or library/API documentation, search the web for current docs.
+
+## Version Control
+
+This repo uses jujutsu (jj) for version control, not git.
+
+### JJ Quick Reference
+
+- `jj status` - Show working copy status
+- `jj log` - Show commit history
+- `jj describe -m "message"` - Set commit message
+- `jj new` - Create new empty commit
+- `jj squash` - Move changes to parent commit
+- `jj split -p <file>` - Split commit by file
+
+**Important:** Never run jj commands that open an editor (like bare `jj describe` or `jj split`). Always use `-m` flag or `JJ_EDITOR="echo 'message'"` prefix.
+
+## Code Search
+
+You are operating in an environment where `ast-grep` is installed. For any code search that requires understanding of syntax or code structure, you should default to using `ast-grep --lang [language] -p '<pattern>'`. Adjust the `--lang` flag as needed for the specific programming language.
+
+## Testing Philosophy
+
+Write two kinds of tests:
+
+1. **Spec tests** - Document intended feature behavior (what the feature should do)
+2. **Regression tests** - Reproduce and prevent actual bugs that occurred
+
+**Skip:** Hypothetical edge cases and exhaustive coverage that bloat context windows.
+
+Tests are living documentation of what should work and what broke before, not comprehensive safety nets for every possibility.
+
+## Python Scripts
+
+Use UV shebang for standalone Python scripts:
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+```

--- a/config/opencode/agent/cursor.md
+++ b/config/opencode/agent/cursor.md
@@ -1,0 +1,15 @@
+# GPT-5 / Cursor Agent
+
+Use this agent when you need deep research, a second opinion, or help fixing a bug. Pass all context including your current findings and the problem you are trying to solve.
+
+## Instructions
+
+You are a senior software architect specializing in rapid codebase analysis and comprehension.
+
+Run the following command with the task and context:
+
+```bash
+cursor-agent -p "TASK and CONTEXT"
+```
+
+Then report back to the user with the result.

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+
+  // Model configuration - using Claude as primary
+  "model": "anthropic/claude-sonnet-4-20250514",
+  "small_model": "anthropic/claude-3-5-haiku-20241022",
+
+  // Provider configuration
+  "provider": {
+    "anthropic": {
+      "apiKey": "{env:ANTHROPIC_API_KEY}"
+    }
+  },
+
+  // Autoupdate - notify but don't auto-update
+  "autoupdate": "notify",
+
+  // Permission configuration
+  // OpenCode uses simpler permission model than Claude Code
+  "permission": {
+    "edit": "allow",
+    "bash": "allow",
+    "webfetch": "allow",
+    "external_directory": "ask"
+  },
+
+  // Tools configuration
+  "tools": {
+    "bash": true,
+    "edit": true
+  },
+
+  // Instructions - global rules from AGENTS.md
+  "instructions": ["~/.config/opencode/AGENTS.md"],
+
+  // MCP servers (if any - translate from Claude settings)
+  "mcp": {}
+}

--- a/modules/shell/opencode.nix
+++ b/modules/shell/opencode.nix
@@ -1,0 +1,32 @@
+{
+  config,
+  options,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+with lib.my;
+let
+  cfg = config.modules.shell.opencode;
+  inherit (config.dotfiles) configDir;
+in
+{
+  options.modules.shell.opencode = {
+    enable = mkBoolOpt false;
+  };
+
+  config = mkIf cfg.enable {
+    user.packages = with pkgs; [
+      # Add opencode-related packages if any
+    ];
+
+    home.configFile = {
+      # OpenCode uses XDG config directory: ~/.config/opencode/
+      "opencode/opencode.json".source = "${configDir}/opencode/opencode.json";
+      "opencode/AGENTS.md".source = "${configDir}/opencode/AGENTS.md";
+      "opencode/agent".source = "${configDir}/opencode/agent";
+      "opencode/command".source = "${configDir}/opencode/command";
+    };
+  };
+}


### PR DESCRIPTION
Translate Claude Code global setup to OpenCode format:
- opencode.json with model, permission, and provider config
- AGENTS.md global rules (from CLAUDE.md)
- cursor.md agent for gpt-5/cursor integration
- opencode.nix module for home-manager integration