### PR TITLE
feat(claude): add GitHub PR review slash commands

### DIFF
--- a/config/claude/plugins/github/.claude-plugin/plugin.json
+++ b/config/claude/plugins/github/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "github",
+  "version": "1.0.0",
+  "description": "GitHub PR review and workflow commands"
+}

--- a/config/claude/plugins/github/commands/pr-review-improve.md
+++ b/config/claude/plugins/github/commands/pr-review-improve.md
@@ -1,0 +1,48 @@
+---
+allowed-tools: Read, Edit
+description: Improve the PR review prompt based on recent review experience
+---
+
+## Your Task
+
+In light of the back and forth in this chat, edit the PR review prompt to reflect anything that might help future PR review plans get to a good place sooner.
+
+### Instructions
+
+1. **Read the current PR review command:**
+   Read the file at `config/claude/plugins/github/commands/pr-review.md`
+
+2. **Analyze the conversation:**
+   - What friction points occurred during the review?
+   - What additional context would have been helpful upfront?
+   - Were there steps that could be combined or reordered?
+   - Did any assumptions prove incorrect?
+   - What edge cases weren't handled?
+
+3. **Identify improvements:**
+   - Missing steps or checks
+   - Better default behaviors
+   - Clearer instructions for ambiguous situations
+   - Additional gh CLI commands that would help
+   - Better formatting for comments or summaries
+
+4. **Update the prompt:**
+   Edit the pr-review.md file with your improvements.
+
+5. **Summarize changes:**
+   Provide a brief summary of what was changed and why.
+
+### Guidelines
+
+- Keep the 6-step structure unless there's a compelling reason to change it
+- Preserve working patterns - only modify what needs improvement
+- Add comments explaining non-obvious decisions
+- Consider both simple PRs and complex multi-file changes
+- Ensure gh CLI commands remain correct and up-to-date
+
+### Example Improvements
+
+- "Added a step to check CI status before reviewing"
+- "Clarified how to handle PRs with merge conflicts"
+- "Added draft PR detection to avoid reviewing unfinished work"
+- "Improved comment formatting for multi-line suggestions"

--- a/config/claude/plugins/github/commands/pr-review.md
+++ b/config/claude/plugins/github/commands/pr-review.md
@@ -1,0 +1,120 @@
+---
+allowed-tools: Bash(gh:*), Bash(git:*), Read
+description: Review a pull request with a structured 6-step workflow
+---
+
+## Your Task
+
+You are helping me review a pull request. Follow this workflow:
+
+### Step 1: Find Relevant PRs
+
+Use `gh pr list` to locate open PRs where I'm assigned, requested as reviewer, or have already reviewed.
+
+```bash
+gh pr list --assignee @me
+gh pr list --search "review-requested:@me"
+gh pr list --search "reviewed-by:@me"
+```
+
+Present results as a numbered list for selection. If a PR number is provided as an argument, skip this step.
+
+### Step 2: Check Out and Examine the PR
+
+1. Check out the PR locally:
+   ```bash
+   gh pr checkout <PR_NUMBER>
+   ```
+
+2. View PR details:
+   ```bash
+   gh pr view <PR_NUMBER>
+   ```
+
+3. Retrieve the full diff:
+   ```bash
+   gh pr diff <PR_NUMBER>
+   ```
+
+4. Examine existing review comments:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments
+   ```
+
+### Step 3: Analyze the Changes
+
+Provide:
+
+1. **High-level summary:**
+   - Purpose of the changes
+   - New APIs or data structures introduced
+   - Dependencies added/modified
+   - Architectural changes
+   - Breaking changes
+   - Impact on existing code
+
+2. **Dependency maintenance checks** (if applicable):
+   - Version bumps and their significance
+   - Security implications
+   - Compatibility concerns
+
+### Step 4: Review Focus Areas
+
+Provide a numbered list of files or directories to review, in logical order. Pay specific attention to:
+
+- **API design:** Consistency, naming, contracts
+- **Complex logic:** Algorithms, state management
+- **Edge cases:** Error handling, boundary conditions
+- **Performance:** Hot paths, memory usage, async patterns
+- **Security:** Input validation, authentication, authorization
+- **Test coverage:** Missing tests, edge case coverage
+- **Style consistency:** Matches codebase conventions
+
+### Step 5: Suggested Comments
+
+Generate specific feedback with file paths and line numbers.
+
+Format each comment as:
+- **File:** `path/to/file.ext`
+- **Line:** `<line_number>`
+- **Comment:** Your specific feedback
+
+**Important:** Verify line numbers by reading the actual file content before suggesting.
+
+### Step 6: Prepare gh CLI Commands
+
+Create the review using the GitHub CLI:
+
+1. **Create a pending review:**
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/reviews \
+     --method POST \
+     --field event=PENDING
+   ```
+
+2. **Add individual line comments:**
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments \
+     --method POST \
+     --field body="<comment>" \
+     --field commit_id="<commit_sha>" \
+     --field path="<file_path>" \
+     --field line=<line_number>
+   ```
+
+3. **Reply to existing comments if needed:**
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/comments/<comment_id>/replies \
+     --method POST \
+     --field body="<reply>"
+   ```
+
+4. **Submit final approval with summary:**
+   ```bash
+   gh pr review <PR_NUMBER> --approve --body "<summary>"
+   ```
+
+   Or request changes:
+   ```bash
+   gh pr review <PR_NUMBER> --request-changes --body "<summary>"
+   ```


### PR DESCRIPTION
Add two slash commands inspired by raf.xyz blog post:
- pr-review: 6-step structured workflow for reviewing PRs
- pr-review-improve: meta-command to iteratively improve the review process