### PR TITLE
Create slash commands from blog post

### DIFF
--- a/config/claude/commands/pr/meta-improve.md
+++ b/config/claude/commands/pr/meta-improve.md
@@ -1,0 +1,102 @@
+---
+allowed-tools: Read, Edit, Glob, Grep
+argument-hint: [pr-number]
+description: Analyze completed PR review to improve future review workflows
+---
+
+## Context
+
+- Review plan command location: !`ls -la ~/.config/claude/commands/pr/ 2>/dev/null || ls -la config/claude/commands/pr/ 2>/dev/null || echo "Commands not found"`
+- Recent PR activity: !`gh pr list --state merged --limit 5 --json number,title,author,mergedAt 2>/dev/null || echo "No recent PRs"`
+
+## Your Task
+
+Run a **meta-improvement loop** on the PR review process. After conducting a review (using `/pr/review-plan`), this command helps analyze what worked and what didn't, then updates the review workflow.
+
+**Key Principle:** "After each review, run a meta-prompt to improve your workflow."
+
+### Step 1: Review Reflection
+
+Ask the human about the just-completed review:
+
+1. **What comments were most valuable?** Which observations actually helped?
+2. **What was missed?** Any issues that slipped through?
+3. **What was noise?** Comments that weren't helpful or were too nitpicky?
+4. **Time spent:** Was the review efficient?
+
+### Step 2: Analyze Patterns
+
+Based on the reflection, identify:
+
+**Effective Patterns:**
+- Types of issues consistently caught
+- File categories that needed most attention
+- Questions that led to productive discussions
+
+**Anti-Patterns:**
+- False positives (flagged but not actual issues)
+- Repeated nitpicks that don't add value
+- Areas where AI analysis was less accurate than human judgment
+
+### Step 3: Generate Improvements
+
+Propose specific changes to the review workflow:
+
+1. **Focus Area Adjustments**
+   - Areas to emphasize more
+   - Areas to de-emphasize
+   - New categories to add
+
+2. **Heuristic Updates**
+   - Patterns that indicate real issues
+   - Patterns that are usually fine
+   - Context-specific rules for this codebase
+
+3. **Efficiency Gains**
+   - Steps that can be parallelized
+   - Checks that can be automated vs need human judgment
+   - Better ways to present findings
+
+### Step 4: Update Review Command
+
+If the human approves, update the `/pr/review-plan` command:
+
+```bash
+# Location of review-plan command
+$DOTFILES/config/claude/commands/pr/review-plan.md
+```
+
+Propose specific edits:
+- Add new focus areas to the checklist
+- Remove or deprioritize unhelpful checks
+- Add codebase-specific patterns
+- Update severity guidelines
+
+### Step 5: Document Learning
+
+Create a brief summary for the human:
+
+```
+REVIEW SESSION SUMMARY
+======================
+PR: #<number>
+Date: <date>
+
+What Worked:
+- <insight 1>
+- <insight 2>
+
+What to Improve:
+- <improvement 1>
+- <improvement 2>
+
+Changes Made:
+- <edit to review-plan.md>
+```
+
+### Important
+
+- This is a **collaborative** improvement process - always ask before making changes
+- Focus on **patterns**, not one-off issues
+- Keep the review command lean - don't add checks that rarely provide value
+- The goal is to make future reviews faster AND more effective

--- a/config/claude/commands/pr/review-plan.md
+++ b/config/claude/commands/pr/review-plan.md
@@ -1,0 +1,83 @@
+---
+allowed-tools: Bash(gh:*), Bash(git:*), Read, Glob, Grep
+argument-hint: <pr-number-or-url>
+description: Generate a structured PR review plan (not the review itself)
+---
+
+## Context
+
+- Current repo: !`git remote get-url origin 2>/dev/null | sed 's/.*github.com[:/]//' | sed 's/.git$//'`
+- Current branch: !`git branch --show-current`
+- Your GitHub user: !`gh api user --jq .login 2>/dev/null || echo "unknown"`
+
+## Your Task
+
+Generate a **review plan** for the specified PR - not the review itself. The human will use your plan to conduct their own review with informed focus areas.
+
+**Key Principle:** "Have the AI generate a _plan_ for your review, not the review itself."
+
+### Step 1: Fetch PR Information
+
+```bash
+# Get PR details
+gh pr view $ARGUMENT --json number,title,author,body,files,additions,deletions,baseRefName,headRefName
+
+# Get the diff
+gh pr diff $ARGUMENT
+```
+
+### Step 2: Analyze and Categorize Changes
+
+Break down the PR by:
+
+1. **File Categories**
+   - New files vs modified files
+   - Test files vs implementation files
+   - Configuration changes
+   - Documentation updates
+
+2. **Change Patterns**
+   - Refactoring (moves/renames)
+   - New functionality
+   - Bug fixes
+   - Dependency changes
+
+### Step 3: Generate Review Focus Areas
+
+Create a prioritized list of areas to examine:
+
+1. **Security Concerns** - Auth, input validation, secrets, SQL injection, XSS
+2. **Edge Cases** - Null handling, error paths, boundary conditions
+3. **Performance** - N+1 queries, unnecessary iterations, memory usage
+4. **Test Coverage** - Are new paths tested? Edge cases covered?
+5. **API Contracts** - Breaking changes, backwards compatibility
+6. **Code Quality** - Naming, duplication, complexity
+
+### Step 4: Prepare Suggested Comments
+
+For each concern, format as:
+
+```
+FILE: path/to/file.ts
+LINE: 42
+CATEGORY: [Security|Performance|Edge Case|Style|Question]
+COMMENT: Your observation here
+SEVERITY: [Blocking|Suggestion|Nitpick]
+```
+
+### Step 5: Output Review Plan
+
+Provide:
+
+1. **Summary** - 2-3 sentence overview of PR purpose and scope
+2. **Risk Assessment** - Low/Medium/High with reasoning
+3. **Focus Areas** - Prioritized list with specific files and lines to examine
+4. **Prepared Comments** - Draft comments for human review (DO NOT post)
+5. **Questions for Author** - Clarifying questions to ask
+
+### Important
+
+- **DO NOT** post comments directly - only prepare them for human review
+- **DO NOT** approve or request changes automatically
+- Present the plan clearly so the human can review alongside the PR diff
+- Be thorough but prioritize - the human's time is valuable


### PR DESCRIPTION
Add two slash commands based on Raf's blog post about AI-generated PRs:

- /pr/review-plan: Generates a structured review plan with focus areas, suggested comments, and risk assessment. Key insight: generate a plan for review, not the review itself.

- /pr/meta-improve: Analyzes completed reviews to improve the workflow. Identifies effective patterns vs anti-patterns and proposes updates to the review-plan command.

Ref: https://www.raf.xyz/blog/03-how-i-keep-up-with-ai-generated-prs