### PR TITLE
feat: route Telegram to Shimmer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -151,6 +151,33 @@
         "type": "github"
       }
     },
+    "blueprint_2": {
+      "inputs": {
+        "nixpkgs": [
+          "openclaw-workspace",
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "openclaw-workspace",
+          "llm-agents",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771437256,
+        "narHash": "sha256-bLqwib+rtyBRRVBWhMuBXPCL/OThfokA+j6+uH7jDGU=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "06ee7190dc2620ea98af9eb225aa9627b68b0e33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
     "brew-src": {
       "flake": false,
       "locked": {
@@ -184,6 +211,44 @@
           "systems"
         ],
         "treefmt-nix": [
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770895533,
+        "narHash": "sha256-v3QaK9ugy9bN9RXDnjw0i2OifKmz2NnKM82agtqm/UY=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "c843f477b15f51151f8c6bcc886954699440a6e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "bun2nix_2": {
+      "inputs": {
+        "flake-parts": [
+          "openclaw-workspace",
+          "llm-agents",
+          "flake-parts"
+        ],
+        "import-tree": "import-tree_2",
+        "nixpkgs": [
+          "openclaw-workspace",
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "openclaw-workspace",
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "openclaw-workspace",
           "llm-agents",
           "treefmt-nix"
         ]
@@ -527,6 +592,28 @@
     "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": [
+          "openclaw-workspace",
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_6": {
+      "inputs": {
+        "nixpkgs-lib": [
           "stylix",
           "nixpkgs"
         ]
@@ -545,7 +632,7 @@
         "type": "github"
       }
     },
-    "flake-parts_6": {
+    "flake-parts_7": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
@@ -649,7 +736,7 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": "systems_10"
+        "systems": "systems_11"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -667,7 +754,7 @@
     },
     "flake-utils_5": {
       "inputs": {
-        "systems": "systems_12"
+        "systems": "systems_13"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -974,6 +1061,21 @@
         "type": "github"
       }
     },
+    "import-tree_2": {
+      "locked": {
+        "lastModified": 1763762820,
+        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
     "lib-extras": {
       "inputs": {
         "devshell": "devshell_2",
@@ -1027,6 +1129,32 @@
         ],
         "systems": "systems_5",
         "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1774582151,
+        "narHash": "sha256-HalbBSniJOt2JtG1dDJWKpNiaMiQu2ubKMwoU8neHB0=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "47ea2efcbe4f4056b320b157e4bdb263dd0000b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "type": "github"
+      }
+    },
+    "llm-agents_2": {
+      "inputs": {
+        "blueprint": "blueprint_2",
+        "bun2nix": "bun2nix_2",
+        "flake-parts": "flake-parts_5",
+        "nixpkgs": [
+          "openclaw-workspace",
+          "nixpkgs"
+        ],
+        "systems": "systems_10",
+        "treefmt-nix": "treefmt-nix_4"
       },
       "locked": {
         "lastModified": 1774582151,
@@ -1462,14 +1590,15 @@
     },
     "openclaw-workspace": {
       "inputs": {
+        "llm-agents": "llm-agents_2",
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1774576804,
-        "narHash": "sha256-jrVr8JI5MZb5RzSSJlWA6rvROUkOpBltKACxSQ7Xbmc=",
+        "lastModified": 1774736405,
+        "narHash": "sha256-6+2nLxd1YOnApyYFehu+JJeUA6S+aNQ4K0T+flkOpl0=",
         "ref": "refs/heads/main",
-        "rev": "08441255cfa8b27513f22b69a097898f53c2c21f",
-        "revCount": 138,
+        "rev": "8a037a8506c889f5a912fd1027f9a425469fabd5",
+        "revCount": 149,
         "type": "git",
         "url": "ssh://git@github.com/edmundmiller/openclaw-workspace"
       },
@@ -1570,7 +1699,7 @@
         "opnix": "opnix",
         "skills-catalog": "skills-catalog",
         "stylix": "stylix",
-        "treefmt-nix": "treefmt-nix_4",
+        "treefmt-nix": "treefmt-nix_5",
         "try": "try",
         "wezterm": "wezterm",
         "zen-browser": "zen-browser"
@@ -1647,13 +1776,13 @@
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
         "firefox-gnome-theme": "firefox-gnome-theme",
-        "flake-parts": "flake-parts_5",
+        "flake-parts": "flake-parts_6",
         "gnome-shell": "gnome-shell",
         "nixpkgs": [
           "nixpkgs"
         ],
         "nur": "nur",
-        "systems": "systems_11",
+        "systems": "systems_12",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
@@ -1721,6 +1850,21 @@
       }
     },
     "systems_12": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_13": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2002,6 +2146,28 @@
     },
     "treefmt-nix_4": {
       "inputs": {
+        "nixpkgs": [
+          "openclaw-workspace",
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773297127,
+        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_5": {
+      "inputs": {
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
@@ -2020,7 +2186,7 @@
     },
     "try": {
       "inputs": {
-        "flake-parts": "flake-parts_6",
+        "flake-parts": "flake-parts_7",
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/hosts/nuc/default.nix
+++ b/hosts/nuc/default.nix
@@ -374,7 +374,7 @@ in
           bindings = [
             {
               peerId = "8357890648"; # @edmundamiller
-              agentId = "edmund";
+              agentId = "shimmer";
             }
             {
               peerId = "8748874608"; # wife


### PR DESCRIPTION
## Summary\n- Bump openclaw-workspace to the latest main so Shimmer is available\n- Route Telegram direct chat 8357890648 to Shimmer\n\n## Verification\n- Verified the live OpenClaw config on nuc now contains the Shimmer agent and Telegram binding\n- Restarted openclaw-gateway successfully\n\n## Notes\n- deploy-rs / home-manager activation on nuc still hits a pre-existing memory-mirror worktree issue, so the live OpenClaw config was patched directly during rollout
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edmundmiller/dotfiles/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
